### PR TITLE
Adds link to related paper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ loop v t = do
   putStrLn str
   loop vNext t1
 ```
+
+# Publications
+
+The concept of `VarT` that this library is built on is isomorphic to Monadic Stream Functions as defined in "[Functional Reactive Programming, Refactored](http://dl.acm.org/citation.cfm?id=2976010)" ([mirror](http://www.cs.nott.ac.uk/~psxip1/#FRPRefactored)).


### PR DESCRIPTION
MSFs as described in "FRP, Refactored" are equivalent to `VarT` up to alpha-renaming. This makes all other properties of MSFs apply to VarTs too.

There is a new paper on MSFs about time transformations and Arrow laws (draft). All of this could be helpful for the users of *varying*.