### PR TITLE
Support the Applicative-Monad proposal and depend on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ newtype Delta = Delta { unDelta :: Float }
 -- An exponential tween back and forth from 0 to 50 over 1 seconds that
 -- loops forever. This spline takes float values of delta time as input,
 -- outputs the current x value at every step.
-tweenx :: (Applicative m, Monad m) => TweenT Float Float m Float
+tweenx :: Monad m => TweenT Float Float m Float
 tweenx = do
     -- Tween from 0 to 50 over 1 second
     tween_ easeOutExpo 0 50 1
@@ -37,18 +37,18 @@ tweenx = do
 
 -- An exponential tween back and forth from 0 to 50 over 1 seconds that never
 -- ends.
-tweeny :: (Applicative m, Monad m) => TweenT Float Float m Float
+tweeny :: Monad m => TweenT Float Float m Float
 tweeny = do
     tween_ easeOutExpo 50 0 1
     tween_ easeOutExpo 0 50 1
     tweeny
 
 -- Our time signal counts input delta time samples.
-time :: (Applicative m, Monad m) => VarT m Delta Float
+time :: Monad m => VarT m Delta Float
 time = var unDelta
 
 -- | Our Point value that varies over time continuously in x and y.
-backAndForth :: (Applicative m, Monad m) => VarT m Delta Point
+backAndForth :: Monad m => VarT m Delta Point
 backAndForth =
     -- Turn our splines into continuous output streams. We must provide
     -- a starting value since splines are not guaranteed to be defined at

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,7 +27,7 @@ easeMiddle start end t = do
 -- An exponential tween back and forth from 0 to 50 over 1 seconds that
 -- loops forever. This spline takes float values of delta time as input,
 -- outputs the current x value at every step.
-tweenx :: (Applicative m, Monad m) => TweenT Float Float m ()
+tweenx :: Monad m => TweenT Float Float m ()
 tweenx = do
     -- Tween from 0 to 50 over 'dur' seconds
     easeMiddle 0 50 dur
@@ -38,14 +38,14 @@ tweenx = do
 
 -- A quadratic tween back and forth from 0 to 50 over 1 seconds that never
 -- ends.
-tweeny :: (Applicative m, Monad m) => TweenT Float Float m ()
+tweeny :: Monad m => TweenT Float Float m ()
 tweeny = do
     easeMiddle 50 0 dur
     easeMiddle 0 50 dur
     tweeny
 
 -- | Our Point value that varies over time continuously in x and y.
-backAndForth :: (Applicative m, Monad m) => VarT m Float Point
+backAndForth :: Monad m => VarT m Float Point
 backAndForth =
     -- Turn our splines into continuous output streams. We must provide
     -- a starting value since splines are not guaranteed to be defined at

--- a/src/Control/Varying/Tween.hs
+++ b/src/Control/Varying/Tween.hs
@@ -138,13 +138,13 @@ runTweenT :: (Monad m, Num f)
           => TweenT f t m x -> f -> f -> m (Either x (t, TweenT f t m x), f)
 runTweenT s dt = runStateT (runSplineT s dt)
 
-scanTween :: (Applicative m, Monad m, Num f)
+scanTween :: (Monad m, Num f)
           => TweenT f t m a -> t -> [f] -> m [t]
 scanTween s t dts = evalStateT (scanSpline s t dts) 0
 
 -- | Converts a tween into a continuous value stream. This is the tween version
 -- of `outputStream`.
-tweenStream :: (Applicative m, Monad m, Num f)
+tweenStream :: (Monad m, Num f)
             => TweenT f t m x -> t -> VarT m f t
 tweenStream s0 t0 = VarT $ f s0 t0 0
   where f s t l i = do (e, l1) <- runTweenT s i l
@@ -168,7 +168,7 @@ tweenStream s0 t0 = VarT $ f s0 t0 0
 -- more than once ;)
 --
 -- `tween` concludes returning the latest output value.
-tween :: (Applicative m, Monad m, Real f, Fractional f, Real t, Fractional t)
+tween :: (Monad m, Real f, Fractional f, Real t, Fractional t)
       => Easing t f -> t -> t -> f -> TweenT f t m t
 tween f start end dur = SplineT g
   where c = end - start
@@ -192,7 +192,7 @@ tween f start end dur = SplineT g
 -- tween f a b c >> return ()
 -- @
 --
-tween_ :: (Applicative m, Monad m, Real t, Fractional t, Real f, Fractional f)
+tween_ :: (Monad m, Real t, Fractional t, Real f, Fractional f)
        => Easing t f -> t -> t -> f -> TweenT f t m ()
 tween_ f a b c = Control.Monad.void (tween f a b c)
 
@@ -201,17 +201,17 @@ tween_ f a b c = Control.Monad.void (tween f a b c)
 -- @
 -- withTween ease from to dur f = mapOutput (pure f) $ tween ease from to dur
 -- @
-withTween :: (Applicative m, Monad m, Real t, Fractional t, Real a, Fractional a)
+withTween :: (Monad m, Real t, Fractional t, Real a, Fractional a)
           => Easing t a -> t -> t -> a -> (t -> x) -> TweenT a x m t
 withTween ease from to dur f = mapOutput (pure f) $ tween ease from to dur
 
 -- | A version of 'withTween' that discards its output.
-withTween_ :: (Applicative m, Monad m, Real t, Fractional t, Real a, Fractional a)
+withTween_ :: (Monad m, Real t, Fractional t, Real a, Fractional a)
            => Easing t a -> t -> t -> a -> (t -> x) -> TweenT a x m ()
 withTween_ ease from to dur f = Control.Monad.void (withTween ease from to dur f)
 
 -- | Creates a tween that performs no interpolation over the duration.
-constant :: (Applicative m, Monad m, Num t, Ord t)
+constant :: (Monad m, Num t, Ord t)
          => a -> t -> TweenT t a m a
 constant value duration = pure value `untilEvent_` after duration
 --------------------------------------------------------------------------------

--- a/varying.cabal
+++ b/varying.cabal
@@ -10,7 +10,7 @@ name:                varying
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.7.0.3
+version:             0.7.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            FRP through value streams and monadic splines.

--- a/varying.cabal
+++ b/varying.cabal
@@ -73,7 +73,7 @@ library
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <5.0
+  build-depends:       base >=4.8 && <5.0
                      , transformers >=0.3
                      , contravariant >= 1.4
 
@@ -87,7 +87,7 @@ executable varying-example
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <5.0
+  build-depends:       base >=4.8 && <5.0
                      , transformers >=0.3
                      , time >=1.4
                      , varying
@@ -106,7 +106,7 @@ test-suite varying-test
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <5.0
+  build-depends:       base >=4.8 && <5.0
                      , time >=1.4
                      , transformers
                      , varying
@@ -126,7 +126,7 @@ benchmark varying-bench
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6
+  build-depends:       base >=4.8
                      , time >=1.4
                      , transformers
                      , varying


### PR DESCRIPTION
Implement issue #21.

Since GHC v7.10.x `Applicative` a required constraint on `Monad`. This PR takes advantage of that fact, by bulk changing paired constraint in favour of `Monad`.

Needs:
- [x] bump of `base` dependencies to 4.8
- [x] maybe bump of `varying` version to 0.7.1
- [ ] maybe remove the warning suppression for redundant constraints

Possible follow-up actions:
 - [ ] Issue to upgrade Travis test matrix (with newer GHCs)
 - [ ] Issue to re-include `varying` into Stackage `nigthtly` (urgent, cutoff date for `lts-12` near)