### PR TITLE
Forget about unsupported GHC versions

### DIFF
--- a/src/Control/Varying/Core.hs
+++ b/src/Control/Varying/Core.hs
@@ -3,9 +3,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-#if __GLASGOW_HASKELL__ > 710
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
 -- |
 --   Module:     Control.Varying.Core
 --   Copyright:  (c) 2015 Schell Scivally
@@ -60,9 +57,7 @@ import           Data.Functor.Contravariant
 import           Data.Functor.Identity
 import           Debug.Trace
 import           Prelude                    hiding (id, (.))
-#if __GLASGOW_HASKELL__ < 710
-import           Data.Monoid
-#endif
+
 --------------------------------------------------------------------------------
 -- Core datatypes
 --------------------------------------------------------------------------------

--- a/src/Control/Varying/Event.hs
+++ b/src/Control/Varying/Event.hs
@@ -19,7 +19,7 @@
 --  is running.  For more info on switching and sequencing streams with events
 --  please check out 'Control.Varying.Spline', which lets you chain together
 --  sequences of values and events using a familiar do-notation.
-{-# LANGUAGE CPP        #-}
+
 module Control.Varying.Event
   ( -- * Event constructors (synonyms of Maybe)
     Event

--- a/src/Control/Varying/Event.hs
+++ b/src/Control/Varying/Event.hs
@@ -20,9 +20,6 @@
 --  please check out 'Control.Varying.Spline', which lets you chain together
 --  sequences of values and events using a familiar do-notation.
 {-# LANGUAGE CPP        #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
 module Control.Varying.Event
   ( -- * Event constructors (synonyms of Maybe)
     Event
@@ -61,11 +58,6 @@ import           Control.Monad
 import           Control.Varying.Core
 import           Data.Foldable        (foldl')
 import           Prelude              hiding (until)
-
--- stuff for FAMP
-#if __GLASGOW_HASKELL__ < 709
-import           Data.Function
-#endif
 
 type Event = Maybe
 

--- a/src/Control/Varying/Spline.hs
+++ b/src/Control/Varying/Spline.hs
@@ -54,12 +54,6 @@ import           Control.Varying.Event
 import           Data.Functor.Identity
 import           Data.Monoid
 
--- stuff for FAMP
-#if __GLASGOW_HASKELL__ < 709
-import Control.Applicative
-import Data.Function
-#endif
-
 -- $setup
 -- >>> import Control.Varying.Time
 

--- a/src/Control/Varying/Spline.hs
+++ b/src/Control/Varying/Spline.hs
@@ -12,7 +12,6 @@
 --  stream. Once that "stream pair" inhibits, the computation completes and
 --  returns a result value. That result value is then used to determine the next
 --  spline in the sequence.
-{-# LANGUAGE CPP              #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}
 {-# LANGUAGE LambdaCase       #-}

--- a/src/Control/Varying/Tween.hs
+++ b/src/Control/Varying/Tween.hs
@@ -68,15 +68,15 @@ import           Data.Functor.Identity     (Identity)
 -- out http://www.gizma.com/easing/.
 --------------------------------------------------------------------------------
 -- | Ease in quadratic.
-easeInQuad :: (Num t, Fractional t, Real f) => Easing t f
+easeInQuad :: (Fractional t, Real f) => Easing t f
 easeInQuad c t b =  c * realToFrac (t*t) + b
 
 -- | Ease out quadratic.
-easeOutQuad :: (Num t, Fractional t, Real f) => Easing t f
+easeOutQuad :: (Fractional t, Real f) => Easing t f
 easeOutQuad c t b =  (-c) * realToFrac (t * (t - 2)) + b
 
 -- | Ease in cubic.
-easeInCubic :: (Num t, Fractional t, Real f) => Easing t f
+easeInCubic :: (Fractional t, Real f) => Easing t f
 easeInCubic c t b =  c * realToFrac (t*t*t) + b
 
 -- | Ease out cubic.
@@ -138,8 +138,7 @@ linear c t b = c * realToFrac t + b
 type TweenT f t m = SplineT f t (StateT f m)
 type Tween f t = TweenT f t Identity
 
-runTweenT :: (Monad m, Num f)
-          => TweenT f t m x -> f -> f -> m (Either x (t, TweenT f t m x), f)
+runTweenT :: TweenT f t m x -> f -> f -> m (Either x (t, TweenT f t m x), f)
 runTweenT s dt = runStateT (runSplineT s dt)
 
 scanTween :: (Monad m, Num f)
@@ -168,12 +167,12 @@ tweenStream s0 t0 = VarT $ f s0 t0 0
 -- | Creates a spline that produces a value interpolated between a start and
 -- end value using an easing equation ('Easing') over a duration.  The
 -- resulting spline will take a time delta as input.
--- Keep in mind `tween` must be fed time deltas, not absolute time or
+-- Keep in mind that `tween` must be fed time deltas, not absolute time or
 -- duration. This is mentioned because the author has made that mistake
 -- more than once ;)
 --
 -- `tween` concludes returning the latest output value.
-tween :: (Monad m, Real f, Fractional f, Real t, Fractional t)
+tween :: (Monad m, Real f, Fractional f, Real t)
       => Easing t f -> t -> t -> f -> TweenT f t m t
 tween f start end dur = SplineT g
   where c = end - start
@@ -197,7 +196,7 @@ tween f start end dur = SplineT g
 -- tween f a b c >> return ()
 -- @
 --
-tween_ :: (Monad m, Real t, Fractional t, Real f, Fractional f)
+tween_ :: (Monad m, Real t, Real f, Fractional f)
        => Easing t f -> t -> t -> f -> TweenT f t m ()
 tween_ f a b c = Control.Monad.void (tween f a b c)
 
@@ -206,12 +205,12 @@ tween_ f a b c = Control.Monad.void (tween f a b c)
 -- @
 -- withTween ease from to dur f = mapOutput (pure f) $ tween ease from to dur
 -- @
-withTween :: (Monad m, Real t, Fractional t, Real a, Fractional a)
+withTween :: (Monad m, Real t, Real a, Fractional a)
           => Easing t a -> t -> t -> a -> (t -> x) -> TweenT a x m t
 withTween ease from to dur f = mapOutput (pure f) $ tween ease from to dur
 
 -- | A version of 'withTween' that discards its output.
-withTween_ :: (Monad m, Real t, Fractional t, Real a, Fractional a)
+withTween_ :: (Monad m, Real t, Real a, Fractional a)
            => Easing t a -> t -> t -> a -> (t -> x) -> TweenT a x m ()
 withTween_ ease from to dur f = Control.Monad.void (withTween ease from to dur f)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 
 module Main where
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ > 710
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
 
 module Main where
 
@@ -12,10 +9,6 @@ import Control.Varying
 import Control.Monad.IO.Class
 import Data.Functor.Identity
 import Data.Time.Clock
-
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 
 main :: IO ()
 main = hspec $ do

--- a/varying.cabal
+++ b/varying.cabal
@@ -59,6 +59,9 @@ source-repository head
 
 library
   ghc-options:         -Wall
+  if impl(ghc >= 8)
+    ghc-options:       -Wno-type-defaults
+
   -- Modules exported by the library.
   exposed-modules:     Control.Varying,
                        Control.Varying.Core,
@@ -85,6 +88,8 @@ library
 
 executable varying-example
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghc >= 8)
+    ghc-options:       -Wno-type-defaults
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.8 && <5.0
@@ -104,6 +109,8 @@ executable varying-example
 test-suite varying-test
   type:                exitcode-stdio-1.0
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghc >= 8)
+    ghc-options:       -Wno-type-defaults
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.8 && <5.0
@@ -124,6 +131,8 @@ test-suite varying-test
 benchmark varying-bench
   type:                exitcode-stdio-1.0
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghc >= 8)
+    ghc-options:       -Wno-type-defaults
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.8


### PR DESCRIPTION
remove options that suppress redundant constraints

Compiles now warning free on GHC 8.2.2.