### PR TITLE
remove senseless arrowapply, fixes #37

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,3 +34,5 @@ change log
 0.7.1.2 - Fixed broken ArrowLoop instance, updated documentation.
 
 0.8.0.0 - TweenT is a newtype.
+
+0.8.1.0 - Remove senseless ArrowApply instance

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ github:              "schell/varying"
 # PVP summary:      +-+------- breaking API changes
 #                   | | +----- non-breaking API additions
 #                   | | | +--- code changes with no API change
-version:             0.8.0.0
+version:             0.8.1.0
 # A short (one-line) description of the package.
 synopsis:            FRP through value streams and monadic splines.
 # A longer description of the package.

--- a/src/Control/Varying/Core.hs
+++ b/src/Control/Varying/Core.hs
@@ -173,11 +173,6 @@ instance Monad m => ArrowChoice (VarT m) where
       (d, g1) <- runVarT g c
       return (d, f ||| g1)
 
-instance Monad m => ArrowApply (VarT m) where
-  app = VarT $ \(v, b) -> do
-    (c, _) <- runVarT v b
-    return (c, app)
-
 -- | Inputs can depend on outputs as long as no time-travel is required.
 --
 -- This isn't the best example but it does make a good test case:

--- a/varying.cabal
+++ b/varying.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 23f79975d60664192d4aec0699c6a80542dc85db8ebfb018fd84bea51c196f7b
+-- hash: 238c3b9ce9b85922d1e595508d4616c90817444c1d7b7e3c85527c9014f90094
 
 name:           varying
-version:        0.8.0.0
+version:        0.8.1.0
 synopsis:       FRP through value streams and monadic splines.
 description:    Varying is a FRP library aimed at providing a simple way to describe values that change over a domain. It allows monadic, applicative and arrow notation and has convenience functions for tweening. Great for animation.
 category:       Control, FRP


### PR DESCRIPTION
Removes the silly `ArrowApply` instance. 